### PR TITLE
feat(epic1): Small Business demo (EPIC 1 complete)

### DIFF
--- a/public/assets/demos/small-business.svg
+++ b/public/assets/demos/small-business.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <rect width="100%" height="100%" fill="#f3f4f6" />
+  <g fill="#111827" font-family="Arial, Helvetica, sans-serif">
+    <text x="60" y="120" font-size="36" font-weight="700">Example Local Service Company</text>
+    <rect x="60" y="150" width="500" height="260" fill="#ffffff" stroke="#e5e7eb" rx="8" />
+    <text x="80" y="190" font-size="18">Hero heading — Clear value proposition</text>
+    <text x="80" y="220" font-size="14" fill="#6b7280">Short supporting paragraph explaining services and CTA.</text>
+    <rect x="640" y="150" width="480" height="260" fill="#ffffff" stroke="#e5e7eb" rx="8" />
+    <text x="660" y="190" font-size="16">Service list / features</text>
+    <text x="660" y="220" font-size="14" fill="#6b7280">Service A • Service B • Service C</text>
+  </g>
+</svg>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>/</loc>
+  </url>
+  <url>
+    <loc>/services</loc>
+  </url>
+  <url>
+    <loc>/demos</loc>
+  </url>
+  <url>
+    <loc>/demos/small-business</loc>
+  </url>
+  <url>
+    <loc>/demo-sites/small-business</loc>
+  </url>
+  <url>
+    <loc>/demo-sites/small-business/services</loc>
+  </url>
+  <url>
+    <loc>/demo-sites/small-business/about</loc>
+  </url>
+  <url>
+    <loc>/demo-sites/small-business/contact</loc>
+  </url>
+</urlset>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,12 +5,20 @@ import { Demos } from './pages/demos/demos';
 import { DemoDetail } from './pages/demo-detail/demo-detail';
 import { About } from './pages/about/about';
 import { Contact } from './pages/contact/contact';
+import { SmallBusinessHome } from './demo-sites/small-business/home';
+import { SmallBusinessServices } from './demo-sites/small-business/services';
+import { SmallBusinessAbout } from './demo-sites/small-business/about';
+import { SmallBusinessContact } from './demo-sites/small-business/contact';
 
 export const routes: Routes = [
   { path: '', component: Home },
   { path: 'services', component: Services },
   { path: 'demos', component: Demos },
   { path: 'demos/:id', component: DemoDetail },
+  { path: 'demo-sites/small-business', component: SmallBusinessHome },
+  { path: 'demo-sites/small-business/services', component: SmallBusinessServices },
+  { path: 'demo-sites/small-business/about', component: SmallBusinessAbout },
+  { path: 'demo-sites/small-business/contact', component: SmallBusinessContact },
   { path: 'about', component: About },
   { path: 'contact', component: Contact },
   { path: '**', redirectTo: '' },

--- a/src/app/demo-sites/small-business/about.css
+++ b/src/app/demo-sites/small-business/about.css
@@ -1,0 +1,2 @@
+.team { padding: var(--spacing-lg) 0; }
+.team p { max-width: 700px; color: var(--color-text-light); }

--- a/src/app/demo-sites/small-business/about.html
+++ b/src/app/demo-sites/small-business/about.html
@@ -1,0 +1,29 @@
+<div class="demo-site">
+  <div class="demo-nav">
+    <a routerLink="/demos">← Back to Demos</a>
+    <nav>
+      <a routerLink="/demo-sites/small-business">Home</a>
+      <a routerLink="/demo-sites/small-business/services">Services</a>
+      <a routerLink="/demo-sites/small-business/about">About</a>
+      <a routerLink="/demo-sites/small-business/contact">Contact</a>
+    </nav>
+  </div>
+
+  <section class="hero">
+    <div class="container">
+      <h1>About Example Local Service Company</h1>
+      <p>We are a local team focused on quality, reliability, and customer satisfaction.</p>
+    </div>
+  </section>
+
+  <section class="team">
+    <div class="container">
+      <h2>Our Approach</h2>
+      <p>We combine experience with local knowledge to deliver dependable services.</p>
+    </div>
+  </section>
+
+  <footer class="demo-footer">
+    <div class="container">© Example Local Service Company</div>
+  </footer>
+</div>

--- a/src/app/demo-sites/small-business/about.ts
+++ b/src/app/demo-sites/small-business/about.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { Title, Meta } from '@angular/platform-browser';
+
+@Component({
+  selector: 'demo-small-business-about',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './about.html',
+  styleUrl: './about.css',
+})
+export class SmallBusinessAbout implements OnInit {
+  constructor(private title: Title, private meta: Meta) {}
+
+  ngOnInit(): void {
+    this.title.setTitle('About — Example Local Service Company');
+    this.meta.updateTag({ name: 'description', content: 'About Example Local Service Company.' });
+  }
+}

--- a/src/app/demo-sites/small-business/contact.css
+++ b/src/app/demo-sites/small-business/contact.css
@@ -1,0 +1,5 @@
+.contact-form { padding: var(--spacing-lg) 0; }
+.contact-form label { display:block; margin-bottom: var(--spacing-md); }
+.contact-form input, .contact-form textarea { width:100%; padding: var(--spacing-sm); border:1px solid var(--color-border); border-radius:4px; }
+.banner.success { background: #e6ffed; border: 1px solid #9ae6b4; padding: var(--spacing-sm); margin-bottom: var(--spacing-md); }
+.banner.error { background: #fff1f2; border: 1px solid #fca5a5; padding: var(--spacing-sm); margin-bottom: var(--spacing-md); }

--- a/src/app/demo-sites/small-business/contact.html
+++ b/src/app/demo-sites/small-business/contact.html
@@ -1,0 +1,47 @@
+<div class="demo-site">
+  <div class="demo-nav">
+    <a routerLink="/demos">← Back to Demos</a>
+    <nav>
+      <a routerLink="/demo-sites/small-business">Home</a>
+      <a routerLink="/demo-sites/small-business/services">Services</a>
+      <a routerLink="/demo-sites/small-business/about">About</a>
+      <a routerLink="/demo-sites/small-business/contact">Contact</a>
+    </nav>
+  </div>
+
+  <section class="hero">
+    <div class="container">
+      <h1>Contact Us</h1>
+      <p>Send us a message and we'll get back to you shortly.</p>
+    </div>
+  </section>
+
+  <section class="contact-form">
+    <div class="container">
+      @if (success();) {
+        <div class="banner success">Thanks — your message was sent.</div>
+      } @else {
+        @if (error(); as err) {
+          <div class="banner error">{{ err }}</div>
+        }
+        <form (submit)="submitForm($event)" netlify="true" name="small-business-contact">
+          <input type="hidden" name="form-name" value="small-business-contact" />
+          <div style="display:none;">
+            <label>Don’t fill this out if you're human: <input name="bot-field" /></label>
+          </div>
+
+          <label>Name*<input name="name" required /></label>
+          <label>Email*<input name="email" type="email" required /></label>
+          <label>Phone<input name="phone" /></label>
+          <label>Message*<textarea name="message" rows="6" required></textarea></label>
+
+          <button class="btn" type="submit" [attr.aria-busy]="loading()">Send</button>
+        </form>
+      }
+    </div>
+  </section>
+
+  <footer class="demo-footer">
+    <div class="container">© Example Local Service Company</div>
+  </footer>
+</div>

--- a/src/app/demo-sites/small-business/contact.ts
+++ b/src/app/demo-sites/small-business/contact.ts
@@ -1,0 +1,55 @@
+import { Component, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { Title, Meta } from '@angular/platform-browser';
+
+@Component({
+  selector: 'demo-small-business-contact',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './contact.html',
+  styleUrl: './contact.css',
+})
+export class SmallBusinessContact {
+  protected readonly loading = signal(false);
+  protected readonly success = signal(false);
+  protected readonly error = signal<string | null>(null);
+
+  constructor(private title: Title, private meta: Meta) {
+    this.title.setTitle('Contact — Example Local Service Company');
+    this.meta.updateTag({ name: 'description', content: 'Contact Example Local Service Company.' });
+  }
+
+  protected submitForm(e: Event) {
+    e.preventDefault();
+    this.error.set(null);
+    const form = e.target as HTMLFormElement;
+    const fd = new FormData(form);
+    const name = (fd.get('name') || '').toString().trim();
+    const email = (fd.get('email') || '').toString().trim();
+    const message = (fd.get('message') || '').toString().trim();
+    const bot = (fd.get('bot-field') || '').toString().trim();
+
+    if (bot) {
+      this.error.set('Spam detected.');
+      return;
+    }
+    if (!name || !email || !message) {
+      this.error.set('Please fill required fields.');
+      return;
+    }
+    const emailRx = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+    if (!emailRx.test(email)) {
+      this.error.set('Please enter a valid email.');
+      return;
+    }
+
+    this.loading.set(true);
+    // Simulated submit (replace with Netlify Forms endpoint if desired)
+    setTimeout(() => {
+      this.loading.set(false);
+      this.success.set(true);
+      console.log('Demo contact submission:', { name, email, message });
+      form.reset();
+    }, 900);
+  }
+}

--- a/src/app/demo-sites/small-business/home.css
+++ b/src/app/demo-sites/small-business/home.css
@@ -1,0 +1,10 @@
+.demo-site .demo-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-lg);
+}
+.demo-site .demo-nav nav a { margin-left: var(--spacing-md); }
+.hero { padding: var(--spacing-xl) 0; background-color: var(--color-background-alt); border-radius: 8px; }
+.hero h1 { margin-bottom: var(--spacing-sm); }
+.demo-footer { margin-top: var(--spacing-xl); padding: var(--spacing-md) 0; color: var(--color-text-light); }

--- a/src/app/demo-sites/small-business/home.html
+++ b/src/app/demo-sites/small-business/home.html
@@ -1,0 +1,30 @@
+<div class="demo-site">
+  <div class="demo-nav">
+    <a routerLink="/demos">← Back to Demos</a>
+    <nav>
+      <a routerLink="/demo-sites/small-business">Home</a>
+      <a routerLink="/demo-sites/small-business/services">Services</a>
+      <a routerLink="/demo-sites/small-business/about">About</a>
+      <a routerLink="/demo-sites/small-business/contact">Contact</a>
+    </nav>
+  </div>
+
+  <section class="hero">
+    <div class="container">
+      <h1>Example Local Service Company</h1>
+      <p>Professional, reliable services for your local needs. We show what you do and make it easy to get in touch.</p>
+      <a routerLink="/demo-sites/small-business/contact" class="btn">Request Service</a>
+    </div>
+  </section>
+
+  <section class="sections">
+    <div class="container">
+      <h2>Our Services</h2>
+      <p>High-quality solutions tailored to local customers, delivered on time and with care.</p>
+    </div>
+  </section>
+
+  <footer class="demo-footer">
+    <div class="container">© Example Local Service Company</div>
+  </footer>
+</div>

--- a/src/app/demo-sites/small-business/home.ts
+++ b/src/app/demo-sites/small-business/home.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { Title, Meta } from '@angular/platform-browser';
+
+@Component({
+  selector: 'demo-small-business-home',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './home.html',
+  styleUrl: './home.css',
+})
+export class SmallBusinessHome implements OnInit {
+  protected readonly company = 'Example Local Service Company';
+  constructor(private title: Title, private meta: Meta) {}
+
+  ngOnInit(): void {
+    this.title.setTitle('Small Business Demo — ' + this.company);
+    this.meta.updateTag({ name: 'description', content: 'A simple brochure demo site for a local service business.' });
+  }
+}

--- a/src/app/demo-sites/small-business/services.css
+++ b/src/app/demo-sites/small-business/services.css
@@ -1,0 +1,3 @@
+.service-list { padding: var(--spacing-lg) 0; }
+.service-list ul { list-style: disc; padding-left: 1.25rem; }
+.service-list a { display: inline-block; margin-top: var(--spacing-md); }

--- a/src/app/demo-sites/small-business/services.html
+++ b/src/app/demo-sites/small-business/services.html
@@ -1,0 +1,33 @@
+<div class="demo-site">
+  <div class="demo-nav">
+    <a routerLink="/demos">← Back to Demos</a>
+    <nav>
+      <a routerLink="/demo-sites/small-business">Home</a>
+      <a routerLink="/demo-sites/small-business/services">Services</a>
+      <a routerLink="/demo-sites/small-business/about">About</a>
+      <a routerLink="/demo-sites/small-business/contact">Contact</a>
+    </nav>
+  </div>
+
+  <section class="hero">
+    <div class="container">
+      <h1>Our Services</h1>
+      <p>We offer a variety of local services tailored to your needs. Quality work, fair pricing.</p>
+    </div>
+  </section>
+
+  <section class="service-list">
+    <div class="container">
+      <ul>
+        <li>Service A — Reliable and fast.</li>
+        <li>Service B — Professional and friendly.</li>
+        <li>Service C — Affordable solutions.</li>
+      </ul>
+      <a routerLink="/demo-sites/small-business/contact" class="btn">Contact Us</a>
+    </div>
+  </section>
+
+  <footer class="demo-footer">
+    <div class="container">© Example Local Service Company</div>
+  </footer>
+</div>

--- a/src/app/demo-sites/small-business/services.ts
+++ b/src/app/demo-sites/small-business/services.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { Title, Meta } from '@angular/platform-browser';
+
+@Component({
+  selector: 'demo-small-business-services',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './services.html',
+  styleUrl: './services.css',
+})
+export class SmallBusinessServices implements OnInit {
+  constructor(private title: Title, private meta: Meta) {}
+
+  ngOnInit(): void {
+    this.title.setTitle('Services — Example Local Service Company');
+    this.meta.updateTag({ name: 'description', content: 'Services offered by Example Local Service Company.' });
+  }
+}

--- a/src/app/pages/about/about.ts
+++ b/src/app/pages/about/about.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { Title, Meta } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-about',
@@ -7,7 +8,7 @@ import { RouterLink } from '@angular/router';
   templateUrl: './about.html',
   styleUrl: './about.css',
 })
-export class About {
+export class About implements OnInit {
   protected readonly technologies = [
     'Angular',
     'TypeScript',
@@ -42,4 +43,10 @@ export class About {
       description: 'Fast-loading, efficient applications that provide excellent user experiences.',
     },
   ];
-}
+    constructor(private title: Title, private meta: Meta) {}
+
+    ngOnInit(): void {
+      this.title.setTitle('About — Kelley Consulting & Web Services');
+      this.meta.updateTag({ name: 'description', content: 'About Kelley Consulting & Web Services.' });
+    }
+  }

--- a/src/app/pages/contact/contact.ts
+++ b/src/app/pages/contact/contact.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-contact',
@@ -8,4 +9,10 @@ import { Component } from '@angular/core';
 })
 export class Contact {
   protected readonly email = 'info@KelleyConsultingWebServices.com';
+  constructor(private title: Title, private meta: Meta) {}
+
+  ngOnInit(): void {
+    this.title.setTitle('Contact — Kelley Consulting & Web Services');
+    this.meta.updateTag({ name: 'description', content: 'Contact Kelley Consulting & Web Services.' });
+  }
 }

--- a/src/app/pages/demo-detail/demo-detail.css
+++ b/src/app/pages/demo-detail/demo-detail.css
@@ -156,6 +156,78 @@
   margin-bottom: var(--spacing-xl);
 }
 
+.cta-actions {
+  display: flex;
+  gap: var(--spacing-md);
+  justify-content: center;
+}
+
+.screenshot-thumb {
+  background: none;
+  border: 1px solid var(--color-border);
+  padding: 0;
+  border-radius: 6px;
+  overflow: hidden;
+  display: block;
+  cursor: pointer;
+}
+
+.demo-screenshot img {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 480px;
+  object-fit: cover;
+}
+
+.screenshot-caption {
+  margin-top: var(--spacing-sm);
+  color: var(--color-text-light);
+  font-size: 0.95rem;
+}
+
+.preview-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+}
+
+.preview-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.preview-inner {
+  position: relative;
+  z-index: 1210;
+  max-width: 95vw;
+  max-height: 90vh;
+}
+
+.preview-inner img {
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+}
+
+.preview-close {
+  position: absolute;
+  right: -8px;
+  top: -8px;
+  background: white;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  font-size: 18px;
+  cursor: pointer;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .overview-content {

--- a/src/app/pages/demo-detail/demo-detail.html
+++ b/src/app/pages/demo-detail/demo-detail.html
@@ -18,13 +18,32 @@
           <div class="overview-text">
             <h2>Overview</h2>
             <p>{{ currentDemo.description }}</p>
+            <h3>What problem this solves</h3>
+            <p>
+              This brochure site helps local businesses present their services clearly,
+              build trust with potential customers, and convert visitors into leads
+              through prominent contact points and persuasive content.
+            </p>
+            <h3>Ideal use case</h3>
+            <p>
+              Small, service-based local businesses (plumbers, landscapers, salons,
+              consultants) that need an online presence to showcase services and
+              capture inquiries.
+            </p>
           </div>
 
-          <div class="demo-placeholder">
-            <div class="placeholder-content">
-              <p>{{ currentDemo.title }}</p>
-              <small>Interactive Demo Preview</small>
-            </div>
+          <div class="demo-screenshot">
+            <button type="button" class="screenshot-thumb" aria-label="Open preview" (click)="openPreview()">
+              <img
+                src="/assets/demos/small-business.svg"
+                alt="Small business demo screenshot"
+                loading="lazy"
+                width="800"
+                height="450"
+                (click)="openPreview('/assets/demos/small-business.svg')"
+              />
+            </button>
+            <div class="screenshot-caption">Click to enlarge preview</div>
           </div>
         </div>
       </div>
@@ -75,10 +94,23 @@
         <div class="cta-content">
           <h2>Interested in a Similar Solution?</h2>
           <p>Let's discuss how we can create a custom web solution for your business needs.</p>
-          <a routerLink="/contact" class="btn">Get In Touch</a>
+          <div class="cta-actions">
+            <a routerLink="/demo-sites/small-business" class="btn primary">Open Live Demo</a>
+            <a routerLink="/contact" class="btn">Request Similar Solution</a>
+          </div>
         </div>
       </div>
     </section>
+
+    @if (previewOpen();) {
+      <div class="preview-modal" role="dialog" aria-modal="true">
+        <div class="preview-inner">
+          <button class="preview-close" (click)="closePreview()">✕</button>
+          <img src="{{ previewSrc() }}" alt="Preview" loading="lazy" width="1200" height="675" />
+        </div>
+        <div class="preview-backdrop" (click)="closePreview()"></div>
+      </div>
+    }
   } @else {
     <section class="section">
       <div class="container">

--- a/src/app/pages/demo-detail/demo-detail.ts
+++ b/src/app/pages/demo-detail/demo-detail.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
+import { Title, Meta } from '@angular/platform-browser';
 
 interface DemoContent {
   id: string;
@@ -19,6 +20,8 @@ interface DemoContent {
 })
 export class DemoDetail implements OnInit {
   protected readonly demo = signal<DemoContent | null>(null);
+  protected readonly previewOpen = signal(false);
+  protected readonly previewSrc = signal<string | null>(null);
 
   private readonly demoData: Record<string, DemoContent> = {
     'small-business': {
@@ -98,13 +101,31 @@ export class DemoDetail implements OnInit {
     },
   };
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(private route: ActivatedRoute, private title: Title, private meta: Meta) {}
 
   ngOnInit(): void {
     this.route.params.subscribe((params) => {
       const id = params['id'];
       const demoContent = this.demoData[id];
       this.demo.set(demoContent || null);
+      if (demoContent) {
+        this.title.setTitle(`${demoContent.title} — Kelley Consulting & Web Services`);
+        this.meta.updateTag({ name: 'description', content: demoContent.subtitle || demoContent.description });
+        this.meta.updateTag({ property: 'og:title', content: demoContent.title });
+        this.meta.updateTag({ property: 'og:description', content: demoContent.subtitle || demoContent.description });
+      }
     });
+  }
+
+  protected openPreview(src?: string) {
+    const resolved = src || '/assets/demos/small-business.svg';
+    console.log('Opening preview for', resolved);
+    this.previewSrc.set(resolved);
+    this.previewOpen.set(true);
+  }
+
+  protected closePreview() {
+    this.previewOpen.set(false);
+    this.previewSrc.set(null);
   }
 }

--- a/src/app/pages/demos/demos.ts
+++ b/src/app/pages/demos/demos.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { Title, Meta } from '@angular/platform-browser';
 
 interface Demo {
   id: string;
@@ -15,7 +16,7 @@ interface Demo {
   templateUrl: './demos.html',
   styleUrl: './demos.css',
 })
-export class Demos {
+export class Demos implements OnInit {
   protected readonly demos: Demo[] = [
     {
       id: 'small-business',
@@ -60,4 +61,10 @@ export class Demos {
       ],
     },
   ];
+  constructor(private title: Title, private meta: Meta) {}
+
+  ngOnInit(): void {
+    this.title.setTitle('Demos — Kelley Consulting & Web Services');
+    this.meta.updateTag({ name: 'description', content: 'Interactive demos and example projects.' });
+  }
 }

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { Title, Meta } from '@angular/platform-browser';
 
 interface DemoCard {
   id: string;
@@ -14,7 +15,7 @@ interface DemoCard {
   templateUrl: './home.html',
   styleUrl: './home.css',
 })
-export class Home {
+export class Home implements OnInit {
   protected readonly demos: DemoCard[] = [
     {
       id: 'small-business',
@@ -38,4 +39,10 @@ export class Home {
       tags: ['Analytics', 'Data Visualization', 'Management'],
     },
   ];
+  constructor(private title: Title, private meta: Meta) {}
+
+  ngOnInit(): void {
+    this.title.setTitle('Home — Kelley Consulting & Web Services');
+    this.meta.updateTag({ name: 'description', content: 'Kelley Consulting & Web Services — modern web solutions for small businesses.' });
+  }
 }

--- a/src/app/pages/services/services.ts
+++ b/src/app/pages/services/services.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
 
 interface Service {
   title: string;
@@ -18,7 +19,7 @@ interface ProcessStep {
   templateUrl: './services.html',
   styleUrl: './services.css',
 })
-export class Services {
+export class Services implements OnInit {
   protected readonly services: Service[] = [
     {
       title: 'Custom Web Development',
@@ -92,4 +93,12 @@ export class Services {
         'We deploy your solution, provide training, and ensure a smooth handoff.',
     },
   ];
+
+  constructor(private title: Title, private meta: Meta) {}
+
+  ngOnInit(): void {
+    this.title.setTitle('Services — Kelley Consulting & Web Services');
+    this.meta.updateTag({ name: 'description', content: 'Services offered by Kelley Consulting & Web Services.' });
+  }
 }
+

--- a/src/assets/demos/small-business.svg
+++ b/src/assets/demos/small-business.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <rect width="100%" height="100%" fill="#f3f4f6" />
+  <g fill="#111827" font-family="Arial, Helvetica, sans-serif">
+    <text x="60" y="120" font-size="36" font-weight="700">Example Local Service Company</text>
+    <rect x="60" y="150" width="500" height="260" fill="#ffffff" stroke="#e5e7eb" rx="8" />
+    <text x="80" y="190" font-size="18">Hero heading — Clear value proposition</text>
+    <text x="80" y="220" font-size="14" fill="#6b7280">Short supporting paragraph explaining services and CTA.</text>
+    <rect x="640" y="150" width="480" height="260" fill="#ffffff" stroke="#e5e7eb" rx="8" />
+    <text x="660" y="190" font-size="16">Service list / features</text>
+    <text x="660" y="220" font-size="14" fill="#6b7280">Service A • Service B • Service C</text>
+  </g>
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,10 @@
   <title>KelleyConsultingWebServices</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Kelley Consulting & Web Services — modern web solutions for small businesses." />
+  <meta property="og:title" content="Kelley Consulting & Web Services" />
+  <meta property="og:description" content="Modern web solutions for small businesses — demos and services." />
+  <meta property="og:type" content="website" />
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>


### PR DESCRIPTION
### Summary
This PR completes EPIC 1 – Small Business Brochure Site demo by finalizing the demo detail page, implementing a realistic brochure-style mini-site, and adding baseline SEO and asset support.

**Key Changes**

**Demo detail page**
- Added structured overview sections: problem statement, feature highlights, tech stack, ideal use case
- Implemented screenshot thumbnail with click-to-expand lightbox
- Added clear CTAs for live demo access and contact
**Small Business demo mini-site**
- Introduced /demo-sites/small-business routes:
  - Home
  - Services
  - About
  - Contact
- Scoped navigation and “Back to Demos” links without impacting main site routing

**Contact form**

- Client-side validation with user feedback
- Honeypot field for basic spam prevention
- Simulated submit flow with success/error states

**SEO & metadata**

- Added per-route page titles and meta descriptions
- Added global OpenGraph defaults
**Assets & infrastructure**

- Added demo screenshot asset (public/assets/demos/small-business.svg)
- Added robots.txt and sitemap.xml for static hosting

**Routing & cleanup**

- Updated routes to support new demo structure
- Minor fixes and cleanup (including ngOnInit placement in About component)